### PR TITLE
Make Strings distinguishable and add support for git-gutter and company

### DIFF
--- a/sorcery-theme.el
+++ b/sorcery-theme.el
@@ -47,7 +47,8 @@
   (c5 "#5f5f87")
   (c6 "#5Fafaf")
   (c7 "#666666")
-  (c8 "#222222")) (
+  (c8 "#222222")
+  (c9 "#999999")) (
 
   ;;; Face weights
   (bold                       (:weight 'bold))
@@ -133,7 +134,7 @@
   (font-lock-preprocessor-face               (:foreground fg))
   (font-lock-regexp-grouping-backslash       (:foreground fg))
   (font-lock-regexp-grouping-construct-face  (:foreground fg))
-  (font-lock-string-face                     (:foreground c7))
+  (font-lock-string-face                     (:foreground c9))
   (font-lock-reference-face                  (:foreground fg))
   (font-lock-type-face                       (:foreground fg))
   (font-lock-variable-name-face              (:foreground fg))

--- a/sorcery-theme.el
+++ b/sorcery-theme.el
@@ -864,6 +864,22 @@
   (vterm-color-cyan     (:foreground c6))
   (vterm-color-white    (:foreground fg))
 
+  ;; git-gutter
+  (git-gutter:added       (:background c2))
+  (git-gutter:deleted     (:background c1))
+  (git-gutter:modified    (:background c3))
+  (git-gutter:unchanged   (:background bg))
+  (git-gutter:separator   (:background c0))
+  (git-gutter-fr:added    (:background c2))
+  (git-gutter-fr:deleted  (:background c1))
+  (git-gutter-fr:modified (:background c3))
+
+  ;; company
+  (company-tooltip-selection (:foreground fg :background c7))
+  (company-tooltip-common (:foreground fg))
+  (company-tooltip (:foreground fg :background c0))
+  (company-scrollbar-bg (:background bg))
+  (company-scrollbar-fg (:background c8))
 
 
   ;;; Language-specific


### PR DESCRIPTION
Hi, I've made `font-lock-string-face` lighter to distinguish it from comments, and defined faces for `git-gutter` and `company`.